### PR TITLE
Allow NULL return types on WidgetUser

### DIFF
--- a/Entity/WidgetUser.php
+++ b/Entity/WidgetUser.php
@@ -44,7 +44,7 @@ class WidgetUser
     /**
      * Get id.
      */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -66,7 +66,7 @@ class WidgetUser
     /**
      * Get config.
      */
-    public function getConfig(): array
+    public function getConfig(): ?array
     {
         return $this->config;
     }


### PR DESCRIPTION
Allow NULL return types on WidgetUser, so you can query if any config if set or not.
(if you use strict typing)